### PR TITLE
chore(deps): Ruff config: adapt src

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ blank_line_after_tag="endif,endblock"
 ignore="H006"
 
 [tool.ruff]
-src = [".", "apis_ontology"]
+src = ["apis_ontology"]
 
 [tool.ruff.format]
 line-ending = "lf"


### PR DESCRIPTION
Remove "." from `[tool.ruff]` config for `src`.
Leaves only apis_ontology as directory when
considering first- vs. third-party imports.