### PR TITLE
ci(dependabot): update Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     # workflows/actions are assumed to be in (have as root) .github/workflows
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     commit-message:
       prefix: "ci"
       include: "scope"
@@ -18,5 +18,5 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "build"
+      prefix: "chore"
       include: "scope"


### PR DESCRIPTION
Change conventional commits message type from
"build" to "chore"; switch to updating GitHub
Actions daily (rather than only weekly).