### PR TITLE
fix: overwrite `MIDDLEWARE` to fix settings for iframes

### DIFF
--- a/apis_ontology/settings.py
+++ b/apis_ontology/settings.py
@@ -39,3 +39,19 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 GIT_REPOSITORY_URL = "https://github.com/acdh-oeaw/apis-instance-tbf"
 
 CSP_FRAME_SRC = ("sennierer.github.io", "https://*.pages.oeaw.ac.at/")
+
+MIDDLEWARE = [
+    "allow_cidr.middleware.AllowCIDRMiddleware",
+    "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "csp.middleware.CSPMiddleware",
+    "crum.CurrentRequestUserMiddleware",
+    # this is used by the apis_core.history module:
+    "simple_history.middleware.HistoryRequestMiddleware",
+]
+


### PR DESCRIPTION

default settings currently uses CSP and XFrameOptionsMiddleware. To be able to set the headers in one middleware only this removes XFrameOptions until its fixed upstream.