### PR TITLE
fix(importers): inherit from BaseEntityImporter

### DIFF
--- a/apis_ontology/importers.py
+++ b/apis_ontology/importers.py
@@ -30,7 +30,7 @@ class EventImporter(BaseEntityImporter):
     pass
 
 
-class PersonImporter(GenericModelImporter):
+class PersonImporter(BaseEntityImporter):
     def mangle_data(self, data):
         if "profession" in data:
             del data["profession"]


### PR DESCRIPTION
Set `PersonImporter` to inherit from `BaseEntityImporter` instead of `GenericModelImporter`, like other existing importers/importer stubs.

Closes: #100