### PR TITLE
feat(tables): add Person full_name column

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -2,6 +2,7 @@ import logging
 
 import django_tables2 as tables
 from apis_core.apis_entities.tables import AbstractEntityTable
+from django.utils.translation import gettext_lazy as _
 
 from .models import (
     Event,
@@ -81,11 +82,15 @@ class ItemTable(TitleFieldsMixin, BaseEntityTable):
 
 
 class PersonTable(BaseEntityTable):
-    surname = SortableLinkifyColumn()
+    full_name = SortableLinkifyColumn(
+        accessor="full_name",
+        verbose_name=_("Name"),
+        order_by=("surname", "forename"),
+    )
 
     class Meta(BaseEntityTable.Meta):
         model = Person
-        fields = ["surname", "forename"]
+        fields = ["full_name", "surname", "forename"]
         order_by = "surname"
 
 


### PR DESCRIPTION
Add (sortable, linkified) custom `full_name` column as default column to `Person` table, replacing
custom `surname` column.
Since `surname` remains included in table Meta variable `fields`, the corresponding column is merely "downgraded" to a regular non-linkified column.

Builds on `full_name` method in `Person` model class, i.e. follows #125. 