### PR TITLE
refactor(tables): update column accessor args

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -2,7 +2,6 @@ import logging
 
 import django_tables2 as tables
 from apis_core.apis_entities.tables import AbstractEntityTable
-from django_tables2.utils import A
 
 from .models import (
     Event,
@@ -28,14 +27,9 @@ class SortableLinkifyColumn(tables.Column):
     link to its detail view.
     """
 
-    linkify = {
-        "viewname": "apis_core:generic:detail",
-        "args": [A("self_contenttype"), A("pk")],
-    }
-
     def __init__(self, *args, **kwargs):
         super().__init__(
-            linkify=self.linkify,
+            linkify=True,
             *args,
             **kwargs,
         )

--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -22,9 +22,7 @@ logger = logging.getLogger(__name__)
 class SortableLinkifyColumn(tables.Column):
     """
     Custom table column which allows sorting of objects
-    in ascending/descending order and which turns the string
-    identifier for each individual object into a clickable
-    link to its detail view.
+    and clicking through to each object's detail view.
     """
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
For custom column `SortableLinkifyColumn`, which
provides linkification of individual objects,
update the reference to the accessor's `content_type` prior to upgrading `apis-core-rdf` to `v0.39.0`,
which removes `self_contenttype` from `RootObject`.