### PR TITLE
fix(posters_import): set leftover variable empty as fallback

### DIFF
--- a/apis_ontology/management/commands/import_poster_data.py
+++ b/apis_ontology/management/commands/import_poster_data.py
@@ -173,7 +173,7 @@ class Command(BaseCommand):
 
             for row in posters_raw_data["rows"]:
                 signature = row["signature"] or ""
-                title = row["title"]  # Poster, Event/Performance field "label"
+                title = row["title"] or ""  # Poster, Event/Performance field "label"
                 storage_location = row["storage_location"] or ""  # Poster field
                 status = row["status"] or ""  # Poster field
                 notes = row["notes"] or ""  # Poster field


### PR DESCRIPTION
Also set `title` variable empty by default to avoid errors based on possible `null` values in raw data.