### PR TITLE
fix(rdfimport): SELECT DISTINCT authors for Works

### DIFF
--- a/apis_ontology/rdfimport/WorkFromDNB.toml
+++ b/apis_ontology/rdfimport/WorkFromDNB.toml
@@ -15,7 +15,7 @@ WHERE {
 # author
 sparql = """
 PREFIX gndo: <https://d-nb.info/standards/elementset/gnd#>
-SELECT ?author
+SELECT DISTINCT ?author
 WHERE {
   ?subject gndo:firstAuthor ?author
 }


### PR DESCRIPTION
When querying GND for `Work` data, use `DISTINCT` for data returned for `firstAuthor` to avoid duplication of `Uris` for same author.