### PR TITLE
feat(posters_import): save signature to Poster field

### DIFF
--- a/apis_ontology/management/commands/import_poster_data.py
+++ b/apis_ontology/management/commands/import_poster_data.py
@@ -307,10 +307,8 @@ class Command(BaseCommand):
                 # add unexpected values and values from columns for which
                 # there are no fields (yet) to Poster field "notes";
                 # relevant for:
-                # signature, measurements, unknown event_types,
+                # measurements, unknown event_types,
                 # start_date_written, end_date_written TODO update
-                if signature:
-                    notes = add_text(notes, f"Signatur: {signature}")
                 if measurements:
                     notes = add_text(notes, f"Maße: {measurements}")
 
@@ -327,6 +325,7 @@ class Command(BaseCommand):
                     country=country,
                     label=title,
                     notes=notes,
+                    signature=signature,
                     status=status,
                     storage_location=storage_location,
                     quantity=quantity,


### PR DESCRIPTION
Save `signature` to dedicated field rather than
appending it to `notes` field.