### PR TITLE
refactor(posters_import): record unknown event_type early

### DIFF
--- a/apis_ontology/management/commands/import_poster_data.py
+++ b/apis_ontology/management/commands/import_poster_data.py
@@ -324,7 +324,14 @@ class Command(BaseCommand):
                         notes, f"Beteiligte Personen: {participants_array}"
                     )
                     notes = add_text(notes, f"Institution: {group_data}")
-
+                elif event_type and event_type not in Event.EventTypes.value + [
+                    "Theater"
+                ]:
+                    # record unknown event type in notes
+                    notes = add_text(
+                        notes,
+                        f"Veranstaltungstyp unbekannt: {event_type}",
+                    )
                 # add any dates to notes field while interval field is not
                 # being used yet TODO replace with interval field
                 if start_date_written:
@@ -610,12 +617,9 @@ class Command(BaseCommand):
                                 obj_content_type=get_ct(Group),
                             )
                     else:
-                        # store unknown event types in notes
                         logger.warning(
                             f"Unknown event type for Poster {title} (ID {(poster_id)})"
                         )
-                        notes = add_text(notes, f"Veranstaltungstyp: {event_type}")
-                        Poster.objects.filter(id=poster_id).update(notes=notes)
 
                 else:
                     logger.warning(


### PR DESCRIPTION
Record unknown `event_type` in `Poster` `notes` field at the same time as other missing or unexpected data rather than leaving it until the end.