### PR TITLE
fix(posters_import): add missing query/fix object reference

### DIFF
--- a/apis_ontology/management/commands/import_poster_data.py
+++ b/apis_ontology/management/commands/import_poster_data.py
@@ -428,12 +428,15 @@ class Command(BaseCommand):
                             # performances with the same label)
                             # TODO remove check once dates (and countries?)
                             #  are saved for performances
-                            performance = PosterPromotedPerformance.objects.get(
+                            related_performance = PosterPromotedPerformance.objects.get(
                                 subj_object_id=poster_id,
                                 subj_content_type=get_ct(Poster),
                                 obj_content_type=get_ct(Performance),
                             )
-                            performance_id = performance.obj_object_id
+                            performance = Performance.objects.get(
+                                id=related_performance.obj_object_id
+                            )
+                            performance_id = performance.pk
                         except ObjectDoesNotExist:
                             performance = Performance.objects.create(
                                 label=title,


### PR DESCRIPTION
Retrieve the actual `Performance` object when an existing `PosterPromotedPerformance` relation is found and rename the variable used for querying the relation so as not to confuse the two (which is currently the case in a later log message, which references the relation object rather than the intended entity object).