### PR TITLE
refactor(posters_import): rename variable for object creation

### DIFF
--- a/apis_ontology/management/commands/import_poster_data.py
+++ b/apis_ontology/management/commands/import_poster_data.py
@@ -328,7 +328,7 @@ class Command(BaseCommand):
 
                 logger.debug(title)
 
-                poster, created = Poster.objects.get_or_create(
+                poster, poster_created = Poster.objects.get_or_create(
                     country=country,
                     label=title,
                     notes=notes,
@@ -340,7 +340,7 @@ class Command(BaseCommand):
                 )
 
                 # log issues with Poster data when creating new objects
-                if created:
+                if poster_created:
                     if poster.label == "":
                         logger.warning(f"Poster ID {poster.id} has no title.")
 


### PR DESCRIPTION
Rename variable which is used to reference if a `Poster` was created or not for later reuse (since we currently indiscriminately use "created" for all of those).