### PR TITLE
feat(posters_import): log event_type problems after object creation

### DIFF
--- a/apis_ontology/management/commands/import_poster_data.py
+++ b/apis_ontology/management/commands/import_poster_data.py
@@ -614,11 +614,13 @@ class Command(BaseCommand):
                                 obj_content_type=get_ct(Group),
                             )
                     else:
-                        logger.warning(
-                            f"Unknown event type for Poster {title} (ID {(poster.pk)})"
-                        )
+                        if poster_created:
+                            logger.warning(
+                                f'No Event created – Poster "{poster.label}" (ID {poster.id}) promotes unknown event_type.'
+                            )
 
                 else:
-                    logger.warning(
-                        f"No event type for Poster {title} (ID {(poster.pk)})"
-                    )
+                    if poster_created:
+                        logger.warning(
+                            f'No Event created – Poster "{poster.label}" (ID {poster.id}) has empty event_type.'
+                        )


### PR DESCRIPTION
Log missing or unknown `Poster` `event_type` – which has missing `Event`/`Performance` relation as consequence – only after inital `Poster` creation.