### PR TITLE
feat(posters_import): log Performance on missing relation

### DIFF
--- a/apis_ontology/management/commands/import_poster_data.py
+++ b/apis_ontology/management/commands/import_poster_data.py
@@ -533,7 +533,7 @@ class Command(BaseCommand):
                             )
                         for director in directors_groups:
                             logger.warning(
-                                f"Missing relation for director group: {director}"
+                                f'Performance "{performance.label}" (ID {performance.pk}) – missing relation PerformanceHadDirectorGroup for {director}.'
                             )
                             # TODO create new Relation PerformanceHadDirectorGroup
                             ...


### PR DESCRIPTION
Log information about `Performance` object affected by missing relation `PerformanceHadDirectorGroup` so the log message is more useful.