### PR TITLE
fix(poster_import): always log missing directors

### DIFF
--- a/apis_ontology/management/commands/import_poster_data.py
+++ b/apis_ontology/management/commands/import_poster_data.py
@@ -519,10 +519,6 @@ class Command(BaseCommand):
                                         forename=person[1],
                                     )
                                     directors_persons.append(director)
-                            else:
-                                logger.warning(
-                                    f"Performance {performance} (ID: {performance.pk}) is missing director"
-                                )
 
                         for director in directors_persons:
                             PerformanceHadDirectorPerson.objects.get_or_create(
@@ -537,6 +533,11 @@ class Command(BaseCommand):
                             )
                             # TODO create new Relation PerformanceHadDirectorGroup
                             ...
+
+                        if not directors_persons and not directors_groups:
+                            logger.warning(
+                                f'Performance "{performance.label}" (ID {performance.pk}) has no director.'
+                            )
 
                         # create relationships between Performance and
                         # participating Persons and Groups


### PR DESCRIPTION
Warn when `Performance` has no director, including when OpenRefine data contains GND references (since it's possible that no entities can be created due
to unexpected object types).