### PR TITLE
feat(posters_import): log data row alongside title

### DIFF
--- a/apis_ontology/management/commands/import_poster_data.py
+++ b/apis_ontology/management/commands/import_poster_data.py
@@ -326,7 +326,7 @@ class Command(BaseCommand):
                 if end_date_written:
                     notes = add_text(notes, f"Datum Ende: {end_date_written}")
 
-                logger.debug(title)
+                logger.debug(f"[{posters_raw_data['rows'].index(row)}] {title}")
 
                 poster, poster_created = Poster.objects.get_or_create(
                     country=country,


### PR DESCRIPTION
When debug logging the `title` of the `Poster` to
import, also always log the current row of the
OpenRefine raw data which is being imported.