### PR TITLE
fix(posters_import): record only valid dates in notes

### DIFF
--- a/apis_ontology/management/commands/import_poster_data.py
+++ b/apis_ontology/management/commands/import_poster_data.py
@@ -334,8 +334,10 @@ class Command(BaseCommand):
                             notes,
                             f"Veranstaltungstyp unbekannt: {event_type}",
                         )
-                    notes = add_text(notes, f"Datum Start: {start_date_written}")
-                    notes = add_text(notes, f"Datum Ende: {end_date_written}")
+                    if start_date_written:
+                        notes = add_text(notes, f"Datum Start: {start_date_written}")
+                    if end_date_written:
+                        notes = add_text(notes, f"Datum Ende: {end_date_written}")
                     notes = add_text(notes, f"Werkbezug: {work_data}")
                     notes = add_text(notes, f"Regisseur: {director_data}")
                     notes = add_text(


### PR DESCRIPTION
For `Posters` without a (valid) `event_type`, only record non-empty start and/or end dates