### PR TITLE
fix(importers): fix date data mangling for PersonImporter

### DIFF
--- a/apis_ontology/importers.py
+++ b/apis_ontology/importers.py
@@ -60,10 +60,10 @@ class PersonImporter(BaseEntityImporter):
     def mangle_data(self, data):
         # sometimes, GND dates are incomplete, e.g. only the year is given
         # but our date fields expect YYYY-MM-DD formatted strings
-        if "date_of_birth" in data:
+        if "date_of_birth" in data and data["date_of_birth"]:
             if len(data["date_of_birth"][0]) < 10:
                 del data["date_of_birth"]
-        if "date_of_death" in data:
+        if "date_of_death" in data and data["date_of_death"]:
             if len(data["date_of_death"][0]) < 10:
                 del data["date_of_death"]
         return data


### PR DESCRIPTION
When `date_of_birth` and `date_of_death` are returned for a `Person` from an external resource, they are assumed to have a length when actually, the keys may be present in the dataset but contain no values (i.e. be empty lists).
This commit fixes this by checking for truthiness of the values for DOB and DOD.

Resolves: #224