### PR TITLE
feat(settings): update order of INSTALLED_APPS

### DIFF
--- a/apis_ontology/settings.py
+++ b/apis_ontology/settings.py
@@ -18,9 +18,11 @@ DEBUG = False
 
 # Application definition
 
-APIS_APPS_PREPEND = ["apis_core.relations"]
-APIS_APPS_APPEND = [
+APIS_APPS_PREPEND = [
     "apis_core.history",
+    "apis_core.relations",
+]
+APIS_APPS_APPEND = [
     "apis_core.documentation",
     "django_interval",
 ]


### PR DESCRIPTION
Move `apis_history` before apps in `apis-acdhch-default-settings` following a recent change to history templates in Core, which requires history to be further up the chain of apps.