### PR TITLE
chore(gitignore): do not ignore locale directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ build
 
 # logging
 *.log
+
+
+# default dir for Django translations
+!**/locale/


### PR DESCRIPTION
Exclude `locale` directories from earlier ignore
rule for files containing the word "local" (for
e.g. local settings) since this is the default
name given to directories for translation files
by Django.