### PR TITLE
feat(settings): remove history

### DIFF
--- a/apis_ontology/settings.py
+++ b/apis_ontology/settings.py
@@ -19,7 +19,6 @@ DEBUG = False
 # Application definition
 
 APIS_APPS_PREPEND = [
-    "apis_core.history",
     "apis_core.relations",
 ]
 APIS_APPS_APPEND = [


### PR DESCRIPTION
Remove `history` dependency in anticipation of it
getting included in `apis-acdhch-default-settings` v2.6.0.