### PR TITLE
chore(gitignore): ignore apis_acdhch_default_settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .env*
 **local**
 /apis_core
+/apis_acdhch_default_settings
 
 # Python-specific
 .*.pyc


### PR DESCRIPTION
Ignore `apis_acdhch_default_settings` directory
so the `apis-acdhch-default-settings` dependency
can be symlinked during local development.