### PR TITLE
refactor(models): update TextChoices constant

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -243,7 +243,7 @@ class Event(BaseEntity):
         CONFERENCE = "Konferenz", _("Konferenz")
         BOOK_READING = "Lesung", _("Lesung")
         SCREENING = "Videovorführung", _("Videovorführung")
-        WORK_IN_PROGRESS = "Vortrag", _("Vortrag")
+        LECTURE = "Vortrag", _("Vortrag")
 
     label = models.CharField(
         blank=True,


### PR DESCRIPTION
Rename `TextChoices` constant used in `Event`
model class inner class `EventTypes` to match
the value it represents.
The current (nonsensical) variable name is
probably an accidental carryover from a
previous project.