### PR TITLE
feat(settings): remove relations from INSTALLED_APPS

### DIFF
--- a/apis_ontology/settings.py
+++ b/apis_ontology/settings.py
@@ -18,9 +18,7 @@ DEBUG = False
 
 # Application definition
 
-APIS_APPS_PREPEND = [
-    "apis_core.relations",
-]
+APIS_APPS_PREPEND = []
 APIS_APPS_APPEND = [
     "apis_core.documentation",
     "django_interval",


### PR DESCRIPTION
Remove `apis_core.relations` from `INSTALLED_APPS` setting in project since it's already being added
by `apis_acdhch_default_settings`, whose settings we are (re)using.