### PR TITLE
feat(settings): add LANGUAGES variable

### DIFF
--- a/apis_ontology/settings.py
+++ b/apis_ontology/settings.py
@@ -9,6 +9,7 @@ Variables are grouped by:
 """
 
 from apis_acdhch_default_settings.settings import *
+from django.utils.translation import gettext_lazy as _
 
 # Django general settings
 
@@ -47,6 +48,10 @@ DATABASES = {
 # https://docs.djangoproject.com/en/5.1/topics/i18n/
 
 LANGUAGE_CODE = "de-at"
+
+LANGUAGES = [
+    ("de", _("German")),
+]
 
 TIME_ZONE = "CET"
 


### PR DESCRIPTION
Add `LANGUAGES` to settings and set it to `de` for German to restrict the available app languages to
just German rather than having Django serve either English or German based on a user's browser settings (which `django.middleware.locale.LocaleMiddleware` does, which was recently added to the `MIDDLEWARE` setting in `apis-acdhcd-default-settings`).