### PR TITLE
chore(gitignore): ignore .mo files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 # Python-specific
 .*.pyc
 __pycache__/
+*.mo
 
 # publishing
 dist


### PR DESCRIPTION
Ignore compiled versions of message files for
gettext (binary files compiled from .po files).