### PR TITLE
feat(models): update rdf_configs

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -1,16 +1,11 @@
-from pathlib import Path
-
 from apis_core.apis_entities.abc import E21_Person, E53_Place, E74_Group
 from apis_core.apis_entities.models import AbstractEntity
 from apis_core.history.models import VersionMixin
 from apis_core.relations.models import Relation
-from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext_lazy
 from django_interval.fields import FuzzyDateParserField
-
-tomls = getattr(settings, "RDF_CONFIGS_DIR", "")
 
 
 class BaseEntity(VersionMixin, AbstractEntity):
@@ -85,9 +80,9 @@ class Work(TitlesMixin, BaseEntity):
 
     @classmethod
     def rdf_configs(cls):
-        return [
-            Path(__file__).parent / tomls / "WorkFromDNB.toml",
-        ]
+        return {
+            "https://d-nb.info/*|/.*.rdf": "WorkFromDNB.toml",
+        }
 
 
 class Expression(TitlesMixin, BaseEntity):
@@ -286,9 +281,9 @@ class Event(BaseEntity):
 
     @classmethod
     def rdf_configs(cls):
-        return [
-            Path(__file__).parent / tomls / "EventFromDNB.toml",
-        ]
+        return {
+            "https://d-nb.info/*|/.*.rdf": "EventFromDNB.toml",
+        }
 
 
 class Performance(BaseEntity):

--- a/apis_ontology/settings.py
+++ b/apis_ontology/settings.py
@@ -73,7 +73,3 @@ DJANGO_TABLES2_TABLE_ATTRS = {
 
 # APIS-specific settings
 GIT_REPOSITORY_URL = "https://github.com/acdh-oeaw/apis-instance-tbf"
-
-
-# Custom project variables
-RDF_CONFIGS_DIR = "triple_configs"


### PR DESCRIPTION
Update `Event` and `Work` model class methods
`rdf_configs` to use new RegEx format for RDF
imports following Core update (`v0.48.0`).
Also remove custom settings variable for location
of RDF configs (directory containing `.toml` files) since Core expects them in an app directory named
`triple_configs` by default anyway.