### PR TITLE
feat(tables): add new default field/column

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -57,7 +57,7 @@ class TitleFieldsMixin(tables.Table):
     title = SortableLinkifyColumn()
 
     class Meta:
-        fields = ["title", "subtitle"]
+        fields = ["title", "subtitle", "other_title_information"]
         order_by = "title"
 
 


### PR DESCRIPTION
Update `TitleFieldsMixin` `fields` value to include `other_title_information` as new default field/column in all tables which inherit from it.