### PR TITLE
feat(forms,filters): exclude Work tbit_category field

### DIFF
--- a/apis_ontology/filtersets.py
+++ b/apis_ontology/filtersets.py
@@ -1,0 +1,17 @@
+import logging
+
+from apis_core.apis_entities.filtersets import AbstractEntityFilterSet
+
+from apis_ontology.forms import WorkFilterSetForm
+
+logger = logging.getLogger(__name__)
+
+
+class BaseEntityFilterSet(AbstractEntityFilterSet):
+    pass
+
+
+class WorkFilterSet(BaseEntityFilterSet):
+    class Meta(BaseEntityFilterSet.Meta):
+        exclude = ["tbit_category"]
+        form = WorkFilterSetForm

--- a/apis_ontology/forms.py
+++ b/apis_ontology/forms.py
@@ -1,0 +1,14 @@
+import logging
+
+from apis_core.generic.forms import GenericFilterSetForm, GenericModelForm
+
+logger = logging.getLogger(__name__)
+
+
+class WorkFilterSetForm(GenericFilterSetForm):
+    columns_exclude = ["tbit_category"]
+
+
+class WorkForm(GenericModelForm):
+    class Meta(GenericModelForm.Meta):
+        exclude = ["tbit_category"]


### PR DESCRIPTION
Add `forms.py` and `filtersets.py` files and create form and filter exclusions for `Work` `tbit_category` field, since the field is not meant to be shown to users (used for work types/genres defined by TB in translation), but should have model validation applied to it, hence not setting it to `editable=False` in models.

Resolves: #302