### PR TITLE
feat(tables): remove superfluous fields

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -82,12 +82,6 @@ class ItemTable(TitleFieldsMixin, BaseEntityTable):
 
 
 class PersonTable(BaseEntityTable):
-    forename = tables.Column(
-        verbose_name=_("forename"),
-    )
-    surname = tables.Column(
-        verbose_name=_("surname"),
-    )
     full_name = SortableLinkifyColumn(
         accessor="full_name",
         verbose_name=_("full name"),


### PR DESCRIPTION
Drop `Person` table fields `forename` and `surname` as they already exist in the model class (in the same form). It's possible they were originally added
while experimenting with translation strings.