### PR TITLE
feat(filters): expand parent filterset class for i18n

### DIFF
--- a/apis_ontology/filtersets.py
+++ b/apis_ontology/filtersets.py
@@ -1,6 +1,8 @@
 import logging
 
 from apis_core.apis_entities.filtersets import AbstractEntityFilterSet
+from django.utils.text import format_lazy
+from django.utils.translation import gettext_lazy as _
 
 from apis_ontology.forms import WorkFilterSetForm
 
@@ -14,7 +16,35 @@ class BaseEntityFilterSet(AbstractEntityFilterSet):
     Applies settings to all entity list views (filter sidebars).
     """
 
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if getattr(self.Meta, "model", False):
+            if "search" in self.filters:
+                s_filter = self.filters["search"]
+                s_filter.label = _("Search across text fields")
+
+                if (help_text := s_filter.extra.get("help_text")) and help_text.split(
+                    ":"
+                ):
+                    fields_string = help_text.split(":")[1]
+                    fields_list = fields_string.split(",")
+
+                    # exclude Thomas Bernhard in translation-specific fields
+                    # from combined search field
+                    fields_list_filtered = ", ".join(
+                        [
+                            f
+                            for f in fields_list
+                            if ("in translation" not in f and "TBit" not in f)
+                        ]
+                    )
+
+                    prefix = _("Searches in:")
+
+                    s_filter.extra["help_text"] = format_lazy(
+                        "{prefix} {fields}", prefix=prefix, fields=fields_list_filtered
+                    )
 
 
 class WorkFilterSet(BaseEntityFilterSet):

--- a/apis_ontology/locale/de/LC_MESSAGES/django.po
+++ b/apis_ontology/locale/de/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-19 10:54+0200\n"
+"POT-Creation-Date: 2025-08-19 11:02+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: K Kollmann <dev-kk@oeaw.ac.at>\n"
 "Language-Team: \n"
@@ -15,6 +15,14 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apis_ontology/filtersets.py
+msgid "Search across text fields"
+msgstr "Textsuche felderübergreifend"
+
+#: apis_ontology/filtersets.py
+msgid "Searches in:"
+msgstr "Sucht in:"
 
 #: apis_ontology/models.py
 msgid "title"


### PR DESCRIPTION
Update `BaseEntityFilterSet` class to modify the default combined search field included in `AbstractEntityFilterSet` so the form field's `label` and `help_text` are also translatable/translated (in addition to its `verbose_name`).