### PR TITLE
fix(translations): update msgid of field help_text

### DIFF
--- a/apis_ontology/locale/de/LC_MESSAGES/django.po
+++ b/apis_ontology/locale/de/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-19 11:45+0200\n"
+"POT-Creation-Date: 2025-08-19 12:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: K Kollmann <dev-kk@oeaw.ac.at>\n"
 "Language-Team: \n"
@@ -151,7 +151,7 @@ msgstr ""
 "26.03.1990 bis 27.03.1990."
 
 #: apis_ontology/models.py
-msgid "Identifier for \"Thomas Bernhard in translation\" publications"
+msgid "Identifier used for \"Thomas Bernhard in translation\" publications"
 msgstr ""
 "Von \"Thomas Bernhard in translation\" verwendete Kennung für Publikationen"
 


### PR DESCRIPTION
Fix `msgid` for `help_text` of `Manifestation` field `tbit_id` in .po file so it mirrors the original string used in models.py.