### PR TITLE
chore(gitignore): ignore .pot files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 .*.pyc
 __pycache__/
 *.mo
+*.pot
 
 # publishing
 dist


### PR DESCRIPTION
Do not include `gettext` template files, which
may be present when `django-admin makemessages`
is run locally with `--keep-pot`.