### PR TITLE
chore(gitignore): narrow exception for locale folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,5 @@ build
 *.log
 
 
-# default dir for Django translations
-!**/locale/
+# exceptions from above ignore rules
+!/apis_ontology/**/locale/


### PR DESCRIPTION
Adapt exception from ignore rules for `locale` folder(s) so it only applies to subdirectories of `apis_ontology`, and update the preceding comment so it acts as section heading for excludes (similar to earlier comments which precede groups of ignore rules).
A less restrictive exception from the previously defined ignore rule for "local" files (meant to prevent inclusion of local settings, variables, versions of files) may cause build tools to include files belonging to other packages/ dependencies present during local development.