### PR TITLE
build: adapt uv dependency groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,16 +17,21 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "deptry>=0.23.1,<0.24",
-    "django-debug-toolbar>=6.0.0,<6.1",
-    "djlint>=1.36.4,<1.37",
-    "pylint>=3.3.8,<3.4",
-    "ruff>=0.12.12,<0.13",
+  {include-group = "helpers"},
+  {include-group = "lint"},
 ]
 docs = [
     "myst-parser>=4.0.1,<4.1",
     "sphinx>=8.2.3,<8.3",
     "sphinx-rtd-theme>=3.0.2,<3.1",
+]
+helpers = [
+    "deptry>=0.23.1,<0.24",
+    "django-debug-toolbar>=6.0.0,<6.1",]
+lint = [
+    "djlint>=1.36.4,<1.37",
+    "pylint>=3.3.8,<3.4",
+    "ruff>=0.12.12,<0.13",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -136,6 +136,15 @@ docs = [
     { name = "sphinx" },
     { name = "sphinx-rtd-theme" },
 ]
+helpers = [
+    { name = "deptry" },
+    { name = "django-debug-toolbar" },
+]
+lint = [
+    { name = "djlint" },
+    { name = "pylint" },
+    { name = "ruff" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -158,6 +167,15 @@ docs = [
     { name = "myst-parser", specifier = ">=4.0.1,<4.1" },
     { name = "sphinx", specifier = ">=8.2.3,<8.3" },
     { name = "sphinx-rtd-theme", specifier = ">=3.0.2,<3.1" },
+]
+helpers = [
+    { name = "deptry", specifier = ">=0.23.1,<0.24" },
+    { name = "django-debug-toolbar", specifier = ">=6.0.0,<6.1" },
+]
+lint = [
+    { name = "djlint", specifier = ">=1.36.4,<1.37" },
+    { name = "pylint", specifier = ">=3.3.8,<3.4" },
+    { name = "ruff", specifier = ">=0.12.12,<0.13" },
 ]
 
 [[package]]


### PR DESCRIPTION
Split `dev` dependency group into sub groups to
separate linters/formatters from other dev tools.