### PR TITLE
fix(data/posters): fix missing formatting for Person data

### DIFF
--- a/data/posters/FTB_posters_initial_catalogue_refined.json
+++ b/data/posters/FTB_posters_initial_catalogue_refined.json
@@ -12486,7 +12486,7 @@
       },
       "participants": [
         {
-          "value": "Kirsten Dene; Ritter, Ilse; Voss, Gert",
+          "value": "Dene, Kirsten; Ritter, Ilse; Voss, Gert",
           "match": null,
           "candidates": []
         },


### PR DESCRIPTION
Fix formatting of `Person` values in `Posters` raw data which leads to unintended duplication of data, which creates complications when trying to reimport data. The original value is missing a comma to separate
the `surname` and `forename` of a `Person` who appears in the dataset more than one.