### PR TITLE
feat(data/posters): add GND info to Group

### DIFF
--- a/data/posters/FTB_posters_initial_catalogue_refined.json
+++ b/data/posters/FTB_posters_initial_catalogue_refined.json
@@ -9148,7 +9148,14 @@
       "group":
       {
         "value": "Salzburger Landestheater",
-        "match": null,
+        "match": {
+          "id": "121748-3",
+          "name": "Salzburger Landestheater",
+          "types": [
+            "AuthorityResource",
+            "CorporateBody"
+          ]
+        },
         "candidates": []
       },
       "country": "AT",


### PR DESCRIPTION
Update raw `Posters` data for a `Group` which appears in the dataset twice, but which is first imported
manually and only later (again) separately from GND, whose resulting two instances cannot be merged into one for some reason (trying to merge them results in a `content_type` mismatch  error).
This change adds the GND data from the one instance in the dataset as `match` value to the one without, which allows the two `Group` items to be recognised as being identical.