### PR TITLE
docs(deps): fix link to djLint docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ add-bounds = "minor"
 resolution = "lowest-direct"
 
 [tool.djlint]
-# djLint config options: https://www.djlint.com/docs/configuration/#options
+# djLint config options: https://djlint.com/docs/configuration/#options
 indent=2
 profile="django"
 extension="html"


### PR DESCRIPTION
The `www` subdomain for the djLint website does
not work anymore -> change URL to naked domain.