### PR TITLE
fix(importers): fix create_instance object duplication

### DIFF
--- a/apis_ontology/importers.py
+++ b/apis_ontology/importers.py
@@ -1,4 +1,13 @@
+import logging
+
+from AcdhArcheAssets.uri_norm_rules import get_normalized_uri
 from apis_core.generic.importers import GenericModelImporter
+from apis_core.uris.models import Uri
+from apis_core.uris.utils import create_object_from_uri
+from django.contrib.contenttypes.models import ContentType
+from django.db.utils import IntegrityError
+
+logger = logging.getLogger(__name__)
 
 
 class BaseEntityImporter(GenericModelImporter):
@@ -6,6 +15,84 @@ class BaseEntityImporter(GenericModelImporter):
     Extends APIS Core's GenericModelImporter class, which provides methods
     for importing data from URIs and creating model instances off of it.
     """
+
+    def create_instance(self):
+        """
+        Adaptation of Core's GenericModelImporter's create_instance method
+        to fix duplication of instances due to import_uri itself not being
+        included in check against existing Uri objects.
+        """
+        logger.debug("Create instance from URI %s", self.import_uri)
+        data = self.get_data(drop_unknown_fields=False)
+        instance = None
+        same_as = data.get("same_as", [])
+        data_uris = [self.import_uri] + [get_normalized_uri(uri) for uri in same_as]
+        if du := Uri.objects.filter(uri__in=data_uris):
+            root_set = set([d.content_object for d in du])
+            if len(root_set) > 1:
+                raise IntegrityError(
+                    f"Multiple objects found for sameAs URIs {data['data_uris']}. "
+                    f"This indicates a data integrity problem as these URIs should be unique."
+                )
+            instance = du.first().content_object
+            logger.debug("Found existing instance %s", instance)
+        if not instance:
+            attributes = {}
+            for field in self.model._meta.fields:
+                if data.get(field.name, False):
+                    attributes[field.name] = data[field.name][0]
+            instance = self.model.objects.create(**attributes)
+            logger.debug("Created instance %s from attributes %s", instance, attributes)
+        content_type = ContentType.objects.get_for_model(instance)
+        for uri in data_uris:
+            Uri.objects.get_or_create(
+                uri=uri, content_type=content_type, object_id=instance.id
+            )
+        for relation, details in data.get("relations", {}).items():
+            rel_app_label, rel_model = relation.split(".")
+            relation_model = ContentType.objects.get_by_natural_key(
+                app_label=rel_app_label, model=rel_model
+            ).model_class()
+
+            reld = details.get("obj", None) or details.get("subj", None)
+            reld_app_label, reld_model = reld.split(".")
+            related_content_type = ContentType.objects.get_by_natural_key(
+                app_label=reld_app_label, model=reld_model
+            )
+            related_model = related_content_type.model_class()
+
+            for related_uri in details["curies"]:
+                try:
+                    related_instance = create_object_from_uri(
+                        uri=related_uri, model=related_model
+                    )
+                    if details.get("obj"):
+                        subj_object_id = instance.pk
+                        subj_content_type = content_type
+                        obj_object_id = related_instance.pk
+                        obj_content_type = related_content_type
+                    else:
+                        obj_object_id = instance.pk
+                        obj_content_type = content_type
+                        subj_object_id = related_instance.pk
+                        subj_content_type = related_content_type
+                    rel, _ = relation_model.objects.get_or_create(
+                        subj_object_id=subj_object_id,
+                        subj_content_type=subj_content_type,
+                        obj_object_id=obj_object_id,
+                        obj_content_type=obj_content_type,
+                    )
+                    logger.debug(
+                        "Created relation %s between %s and %s",
+                        relation_model.name(),
+                        rel.subj,
+                        rel.obj,
+                    )
+                except Exception as e:
+                    logger.error(
+                        "Could not create relation to %s due to %s", related_uri, e
+                    )
+        return instance
 
 
 class EventImporter(BaseEntityImporter):


### PR DESCRIPTION
Override `create_instance` method inherited from Core's `GenericModelImporter` class to fix object duplication which occurs when the originating import URI, `import_uri`, already exists in `Uris`.
The fix consists of including `import_uri` in the list of data URIs which are looked up in `Uris` to fetch existing content objects for the URIs (to subsequently link any additional URIs with these objects rather than create new objects off of them).