### PR TITLE
fix(data/translations): correct duplicate GND ID

### DIFF
--- a/data/translations/translators.json
+++ b/data/translations/translators.json
@@ -1750,7 +1750,7 @@
 		"name": "Denić, Bojana"
 	},
 	{
-		"gnd": "115835970",
+		"gnd": "103511075",
 		"id": 356,
 		"name": "Krasni, Zlatko"
 	},


### PR DESCRIPTION
Update duplicate GND ID in translations raw data
to GND ID which matches other available data for
the object (`Person` `name` value).