### PR TITLE
fix(tables): use correct source for DuplicateColumn

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -1,9 +1,11 @@
 import logging
 
 import django_tables2 as tables
+from apis_core.apis_entities.tables import (
+    DuplicateColumn,
+)
 from apis_core.generic.tables import (
     DeleteColumn,
-    DuplicateColumn,
     EditColumn,
     ViewColumn,
 )


### PR DESCRIPTION
Fix `import` statement for `DuplicateColumn`, which was prematurely set to Core `generic` app in commit b3c38ff. (The column is moved from `apis_entitites` to `generic` only in Core version `v0.56.0`; the project is currently still on version `v0.54.2`.)