### PR TITLE
feat(rdfimport): readd GroupFromDNB config

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -339,6 +339,13 @@ class Group(BaseEntity, E74_Group):
     class Meta(E74_Group.Meta):
         pass
 
+    @classmethod
+    def rdf_configs(cls):
+        return {
+            "https://d-nb.info/*|/.*.rdf": "GroupFromDNB.toml",
+            "http://www.wikidata.org/*|/.*.rdf": "E74_GroupFromWikidata.toml",
+        }
+
 
 class Event(BaseEntity):
     """

--- a/apis_ontology/triple_configs/GroupFromDNB.toml
+++ b/apis_ontology/triple_configs/GroupFromDNB.toml
@@ -1,0 +1,17 @@
+[[filters]]
+"rdf:type" = "gndo:CorporateBody"
+
+[[filters]]
+"rdf:type" = "gndo:Company"
+
+[[filters]]
+"rdf:type" = "gndo:MusicalCorporateBody"
+
+[[filters]]
+"rdf:type" = "gndo:OrganOfCorporateBody"
+
+[attributes]
+label = ["gndo:preferredNameForTheCorporateBody", "gndo:variantNameForTheCorporateBody"]
+start_date = "gndo:dateOfEstablishment"
+end_date = "gndo:dateOfTermination"
+sameas = "owl:sameAs"


### PR DESCRIPTION
Readd project-specific `GroupFromDNB` triple config so missing filters for GND RDF types `MusicalCorporateBody` and `OrganOfCorporateBodyproject` are covered.