### PR TITLE
revert: "feat(settings): add apis_core.uris to INSTALLED_APPS"

### DIFF
--- a/apis_ontology/settings.py
+++ b/apis_ontology/settings.py
@@ -23,7 +23,6 @@ APIS_APPS_PREPEND = []
 APIS_APPS_APPEND = [
     "apis_core.documentation",
     "django_interval",
-    "apis_core.uris",
 ]
 
 for a in APIS_APPS_PREPEND:


### PR DESCRIPTION
(Partially) Revert commit which temporarily added `apis_core.uris`
to `INSTALLED_APPS` because the app had not yet been added to
`apis_acdhch_default_settings` (from which we inherit).
Seeing as the app has since been added to the dependency,
it shouldn't get included a second time.

This reverts changes made to `settings.py` in commit
https://github.com/acdh-oeaw/apis-instance-tbf/commit/77c5a28ba89647f1bbfd2733a65ce7b382ba2f68. The other files
affected by the original commit, `pyproject.toml` and `uv.lock`,
are left untouched.