### PR TITLE
feat(api/tbit): set up API for translations data

### DIFF
--- a/apis_ontology/api/tbit/__init__.py
+++ b/apis_ontology/api/tbit/__init__.py
@@ -1,0 +1,3 @@
+"""
+API endpoints for TBit – Thomas Bernhard in translation project.
+"""

--- a/apis_ontology/settings.py
+++ b/apis_ontology/settings.py
@@ -71,5 +71,10 @@ DJANGO_TABLES2_TABLE_ATTRS = {
     },
 }
 
+# Django REST framework settings
+REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"] = (
+    "rest_framework.permissions.IsAuthenticatedOrReadOnly",
+)
+
 # APIS-specific settings
 GIT_REPOSITORY_URL = "https://github.com/acdh-oeaw/apis-instance-tbf"

--- a/apis_ontology/urls.py
+++ b/apis_ontology/urls.py
@@ -1,0 +1,11 @@
+from apis_acdhch_default_settings.urls import urlpatterns
+from django.urls import include, path
+from rest_framework import routers
+
+router = routers.DefaultRouter()
+
+urlpatterns += [
+    path(
+        "api/tbit/", include((router.urls, "apis_ontology.api.tbit"), namespace="tbit")
+    ),
+]


### PR DESCRIPTION
Add `urls.py` file to project and include path to root for API endpoints for Thomas Bernhard in translation datasets. (So far, `urls.py` was inherited as-is from `apis_acdhch_default_settings` and thus could be left off/was left off for DRY-ness.)
Also add `__init__.py` for new `api/tbit` package for TBit API files and add Django REST framework permissions setting `IsAuthenticatedOrReadOnly` to `settings.py`.