### PR TITLE
feat(api/tbit): add API endpoint for TBit works

### DIFF
--- a/apis_ontology/api/tbit/serializers.py
+++ b/apis_ontology/api/tbit/serializers.py
@@ -1,0 +1,30 @@
+import re
+
+from apis_core.generic.serializers import (
+    GenericHyperlinkedModelSerializer,
+)
+from rest_framework.fields import SerializerMethodField
+from rest_framework.serializers import ModelSerializer
+
+from apis_ontology.models import (
+    Work,
+)
+
+
+class WorkSerializer(GenericHyperlinkedModelSerializer, ModelSerializer):
+    category = SerializerMethodField()
+    short_title = SerializerMethodField()
+
+    class Meta:
+        model = Work
+        fields = ["id", "title", "short_title", "category", "url"]
+
+    def get_category(self, obj):
+        return obj.tbit_category
+
+    def get_short_title(self, obj):
+        if (
+            other_title_info := obj.other_title_information
+        ) and "short title" in other_title_info:
+            if short_title := re.search(r"\(short title: (.*)\)", other_title_info):
+                return short_title.group(1)

--- a/apis_ontology/api/tbit/views.py
+++ b/apis_ontology/api/tbit/views.py
@@ -1,0 +1,14 @@
+from rest_framework import viewsets
+
+from apis_ontology.models import (
+    Work,
+)
+
+from .serializers import (
+    WorkSerializer,
+)
+
+
+class WorkViewSet(viewsets.ReadOnlyModelViewSet):
+    serializer_class = WorkSerializer
+    queryset = Work.objects.all().exclude(tbit_category__exact="")

--- a/apis_ontology/urls.py
+++ b/apis_ontology/urls.py
@@ -2,7 +2,13 @@ from apis_acdhch_default_settings.urls import urlpatterns
 from django.urls import include, path
 from rest_framework import routers
 
+from apis_ontology.api.tbit.views import (
+    WorkViewSet,
+)
+
 router = routers.DefaultRouter()
+
+router.register(r"works", WorkViewSet, basename="work")
 
 urlpatterns += [
     path(


### PR DESCRIPTION
Add files `serializers.py` and `views.py` for Thomas Bernhard in translation API endpoints, with classes `WorkSerializer` and `WorkViewSet` for first endpoint for TBit works, which mirrors (most of) the data structure in `works.json`. Also add route `works` to `urls.py`.