### PR TITLE
fix(urls): fix URL conf for TBit API

### DIFF
--- a/apis_ontology/urls.py
+++ b/apis_ontology/urls.py
@@ -11,7 +11,5 @@ router = routers.DefaultRouter()
 router.register(r"works", WorkViewSet, basename="work")
 
 urlpatterns += [
-    path(
-        "api/tbit/", include((router.urls, "apis_ontology.api.tbit"), namespace="tbit")
-    ),
+    path("api/tbit/", include((router.urls, "apis_ontology"))),
 ]


### PR DESCRIPTION
Fix nonsensical inclusion of root URL for TBit API (a potential leftover from earlier experiments).