### PR TITLE
fix(settings): set ROOT_URLCONF to use project urls

### DIFF
--- a/apis_ontology/settings.py
+++ b/apis_ontology/settings.py
@@ -33,6 +33,7 @@ for a in APIS_APPS_APPEND:
     if a not in INSTALLED_APPS:
         INSTALLED_APPS.append(a)
 
+ROOT_URLCONF = "apis_ontology.urls"
 
 WSGI_APPLICATION = "apis_ontology.wsgi.application"
 


### PR DESCRIPTION
Add `ROOT_URLCONF` variable to project settings to override value set in/inherited from `apis_acdhch_default_settings`, so `urlpatterns` are picked up from project's own `urls.py` file.