### PR TITLE
refactor(api/tbit): simplify WorkSerializer category field

### DIFF
--- a/apis_ontology/api/tbit/serializers.py
+++ b/apis_ontology/api/tbit/serializers.py
@@ -12,15 +12,14 @@ from apis_ontology.models import (
 
 
 class WorkSerializer(GenericHyperlinkedModelSerializer, ModelSerializer):
-    category = SerializerMethodField()
     short_title = SerializerMethodField()
 
     class Meta:
         model = Work
         fields = ["id", "title", "short_title", "category", "url"]
-
-    def get_category(self, obj):
-        return obj.tbit_category
+        extra_kwargs = {
+            "category": {"source": "tbit_category"},
+        }
 
     def get_short_title(self, obj):
         if (


### PR DESCRIPTION
`category` is basically an alias for `Manifestation` field `tbit_category`, thus needn't be constructed with a `SerializerMethodField`.
It doesn't need to be declared explicitly on the serializer at all because `extra_kwargs` allows setting of arguments on fields, including `source` to point to an existing model field. This coincidentally conveniently circumvents having to pick the most appropriate serializer field for the model field data type.