### PR TITLE
refactor(api/tbit): add ShortTitleMixin serializer for DRY-ness

### DIFF
--- a/apis_ontology/api/tbit/serializers.py
+++ b/apis_ontology/api/tbit/serializers.py
@@ -4,7 +4,7 @@ from apis_core.generic.serializers import (
     GenericHyperlinkedModelSerializer,
 )
 from rest_framework.fields import IntegerField, SerializerMethodField
-from rest_framework.serializers import ModelSerializer
+from rest_framework.serializers import ModelSerializer, Serializer
 
 from apis_ontology.models import (
     Manifestation,
@@ -23,9 +23,51 @@ class BaseEntitySerializer(GenericHyperlinkedModelSerializer):
     id = IntegerField(source="pk")
 
 
-class WorkSerializer(BaseEntitySerializer, ModelSerializer):
-    short_title = SerializerMethodField()
+class ShortTitleMixin(Serializer):
+    """
+    Mixin to recreate TBit "short_title" values from information (temporarily)
+    stored in the "other_title_information" field, and to return the latter
+    sans this information.
 
+    When TBit data was imported, "short_title" values, where present, were
+    added to the "other_title_information" field (which is meant to hold extra
+    information like issue numbers/names etc.) in the form "(short title:
+    $SHORT_TITLE_VALUE)" as a temporary measure so as not to lose any data.
+    No separate field was created for "short_title"s because they appear only
+    in conjunction with exceptionally long "title" values (which seem to include
+    subtitles, for which there is actually a separate field), presumably
+    to differentiate between "common" (shortened) titles and full titles.
+    """
+
+    short_title = SerializerMethodField()
+    other_title_information = SerializerMethodField()  # overrides model field raw value
+
+    def get_short_title(self, obj):
+        """
+        Extract TBit "short_title" information from "other_title_information"
+        field (where that information exists), until long titles are sorted out.
+        """
+        if (
+            other_title_info := obj.other_title_information
+        ) and "short title" in other_title_info:
+            if short_title := re.search(r"\(short title: (.*)\)", other_title_info):
+                return short_title.group(1)
+
+    def get_other_title_information(self, obj):
+        """
+        Return "other_title_information" field contents sans TBit "short_title"
+        information, which was parked in the field.
+        """
+        if other_title_info := obj.other_title_information:
+            manifestation_metadata = re.sub(
+                r"\(short title: .*\)", "", other_title_info
+            )
+            if manifestation_metadata:
+                return manifestation_metadata
+        return ""
+
+
+class WorkSerializer(BaseEntitySerializer, ShortTitleMixin, ModelSerializer):
     class Meta:
         model = Work
         fields = ["id", "title", "short_title", "category", "url"]
@@ -33,18 +75,9 @@ class WorkSerializer(BaseEntitySerializer, ModelSerializer):
             "category": {"source": "tbit_category"},
         }
 
-    def get_short_title(self, obj):
-        if (
-            other_title_info := obj.other_title_information
-        ) and "short title" in other_title_info:
-            if short_title := re.search(r"\(short title: (.*)\)", other_title_info):
-                return short_title.group(1)
 
-
-class ManifestationSerializer(BaseEntitySerializer, ModelSerializer):
-    short_title = SerializerMethodField()
+class ManifestationSerializer(BaseEntitySerializer, ShortTitleMixin, ModelSerializer):
     publication_details = SerializerMethodField()
-    other_title_information = SerializerMethodField()  # overrides model field raw value
 
     class Meta:
         model = Manifestation
@@ -75,23 +108,6 @@ class ManifestationSerializer(BaseEntitySerializer, ModelSerializer):
 
         return ret
 
-    def get_other_title_information(self, obj):
-        """
-        Return Manifestation field "other_title_information" sans temporarily
-        stored info on short titles.
-
-        Filters out occurrences of "(short title: $SHORT_TITLE_VALUE)" substring
-        and returns any remaining field contents, which may include further
-        information about Manifestations, like issue names, issue numbers etc.
-        """
-        if other_title_info := obj.other_title_information:
-            manifestation_metadata = re.sub(
-                r"\(short title: .*\)", "", other_title_info
-            )
-            if manifestation_metadata:
-                return manifestation_metadata
-        return ""
-
     def get_publication_details(self, obj):
         """
         Combine values stored in Manifestation fields "other_title_information"
@@ -112,18 +128,3 @@ class ManifestationSerializer(BaseEntitySerializer, ModelSerializer):
 
         if publication_details:
             return ", ".join(publication_details)
-
-    def get_short_title(self, obj):
-        """
-        Extract TBit "short_title" info (if it exists) from Manifestation field
-        "other_title_information", where it was added in the form
-        "(short title: $SHORT_TITLE_VALUE)" until long titles are sorted out.
-
-        The assumption is long TBit titles include subtitles, which need manual
-        saving/transferring to the subtitles field following a review.
-        """
-        if (
-            other_title_info := obj.other_title_information
-        ) and "short title" in other_title_info:
-            if short_title := re.search(r"\(short title: (.*)\)", other_title_info):
-                return short_title.group(1)


### PR DESCRIPTION
Add `ShortTitleMixin` to separate Thomas Bernhard in translation `short_title` values from extra title information stored in `other_title_information` field to prevent code duplication in `WorkSerializer` and `ManifestationSerializer`.
The short title information ought to be reviewed as it appears to combine titles and subtitles (for which there is a separate field) but until then, this mixin serves to split out these short titles and to return any original (non-short title) data already held in `other_title_information` for any entities created based on TBit data with `short_title` values (which are entities with an `other_title_information` field via `TitlesMixin`).