### PR TITLE
refactor(urls): move TBit-related URLs to api/tbit/

### DIFF
--- a/apis_ontology/api/tbit/urls.py
+++ b/apis_ontology/api/tbit/urls.py
@@ -1,0 +1,20 @@
+"""
+URLs relevant to API endpoints provided for Thomas Bernhard in translation.
+"""
+
+from django.urls import include, path
+from rest_framework import routers
+
+from apis_ontology.api.tbit.views import (
+    ManifestationViewSet,
+    WorkViewSet,
+)
+
+router = routers.DefaultRouter()
+
+router.register(r"works", WorkViewSet, basename="work")
+router.register(r"publications", ManifestationViewSet, basename="publication")
+
+urlpatterns = [
+    path("api/tbit/", include((router.urls, "apis_ontology"))),
+]

--- a/apis_ontology/urls.py
+++ b/apis_ontology/urls.py
@@ -1,17 +1,5 @@
 from apis_acdhch_default_settings.urls import urlpatterns
-from django.urls import include, path
-from rest_framework import routers
 
-from apis_ontology.api.tbit.views import (
-    ManifestationViewSet,
-    WorkViewSet,
-)
+from .api.tbit.urls import urlpatterns as tbit_urls
 
-router = routers.DefaultRouter()
-
-router.register(r"works", WorkViewSet, basename="work")
-router.register(r"publications", ManifestationViewSet, basename="publication")
-
-urlpatterns += [
-    path("api/tbit/", include((router.urls, "apis_ontology"))),
-]
+urlpatterns += tbit_urls


### PR DESCRIPTION
Move `urlpatterns` for TBit API endpoints to a separate `urls.py` file in `api/tbit/` so they are grouped with the rest of the files relevant to the API (i.e.
`views.py` and `serializers.py` so far) and import them into the main `urls.py` file of the app from there.