### PR TITLE
feat(api/tbit): create route/endpoint for TBit translators

### DIFF
--- a/apis_ontology/api/tbit/urls.py
+++ b/apis_ontology/api/tbit/urls.py
@@ -7,6 +7,7 @@ from rest_framework import routers
 
 from apis_ontology.api.tbit.views import (
     ManifestationViewSet,
+    PersonIsTranslatorViewSet,
     WorkViewSet,
 )
 
@@ -14,6 +15,7 @@ router = routers.DefaultRouter()
 
 router.register(r"works", WorkViewSet, basename="work")
 router.register(r"publications", ManifestationViewSet, basename="publication")
+router.register(r"translators", PersonIsTranslatorViewSet, basename="translator")
 
 urlpatterns = [
     path("api/tbit/", include((router.urls, "apis_ontology"))),

--- a/apis_ontology/api/tbit/views.py
+++ b/apis_ontology/api/tbit/views.py
@@ -2,11 +2,13 @@ from rest_framework import viewsets
 
 from apis_ontology.models import (
     Manifestation,
+    PersonIsTranslatorOfExpression,
     Work,
 )
 
 from .serializers import (
     ManifestationSerializer,
+    PersonIsTranslatorSerializer,
     WorkSerializer,
 )
 
@@ -23,3 +25,14 @@ class ManifestationViewSet(viewsets.ReadOnlyModelViewSet):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.name = f"Publication {self.suffix}"
+
+
+class PersonIsTranslatorViewSet(viewsets.ReadOnlyModelViewSet):
+    serializer_class = PersonIsTranslatorSerializer
+    queryset = PersonIsTranslatorOfExpression.objects.order_by(
+        "subj_object_id"
+    ).distinct("subj_object_id")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.name = f"Translator {self.suffix}"


### PR DESCRIPTION
Add `PersonSerializer`, `PersonIsTranslatorSerializer`, `PersonIsTranslatorViewSet` and new path `translators` for new API endpoint.
`PersonSerializer` serializes `Person` objects so they include a `url` and `name` field which replicates TBit's `name` field (format) for people's full names.
`PersonIsTranslatorSerializer` serializes instances of the `PersonIsTranslatorOfExpression` relationship which actually resolve to persons, i.e. which don't have "dangling" subjects of `None`. (Missing `Expression` objects at the other end of the relation, however, are ignored for this purpose.)
`PersonIsTranslatorViewSet` limits the full list of objects to distinct translators.