### PR TITLE
fix(deps): add, pin Django to fix autocomplete errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "apis-acdhch-default-settings>=2.15.0,<2.16",
     "apis-core-rdf>=0.56.4,<0.57",
     "django-interval>=0.5.1,<0.6",
+    "django~=5.2",
     "psycopg-binary>=3.3.2,<3.4",
     "psycopg>=3.3.2,<3.4",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -115,6 +115,7 @@ source = { editable = "." }
 dependencies = [
     { name = "apis-acdhch-default-settings" },
     { name = "apis-core-rdf" },
+    { name = "django" },
     { name = "django-interval" },
     { name = "psycopg" },
     { name = "psycopg-binary" },
@@ -147,6 +148,7 @@ lint = [
 requires-dist = [
     { name = "apis-acdhch-default-settings", specifier = ">=2.15.0,<2.16" },
     { name = "apis-core-rdf", specifier = ">=0.56.4,<0.57" },
+    { name = "django", specifier = "~=5.2" },
     { name = "django-interval", specifier = ">=0.5.1,<0.6" },
     { name = "psycopg", specifier = ">=3.3.2,<3.4" },
     { name = "psycopg-binary", specifier = ">=3.3.2,<3.4" },


### PR DESCRIPTION
Add Django as dependency and pin it at version `5.2.0` to prevent `django-autocomplete-light` errors due to the latter clashing with the newest Django release (`6.0`, which is automatically installed via Core, which only has a minimum required version setting for Django), which ultimately results in deployments failing.