### PR TITLE
refactor(models): move EventTypes out of Event

### DIFF
--- a/apis_ontology/management/commands/import_poster_data.py
+++ b/apis_ontology/management/commands/import_poster_data.py
@@ -11,6 +11,7 @@ from apis_ontology.models import (
     Event,
     EventHadParticipantGroup,
     EventHadParticipantPerson,
+    EventTypes,
     Group,
     Performance,
     PerformanceHadDirectorPerson,
@@ -268,9 +269,7 @@ class Command(BaseCommand):
                 if measurements:
                     notes = add_text(notes, f"Maße: {measurements}")
 
-                if not event_type or event_type not in Event.EventTypes.values + [
-                    "Theater"
-                ]:
+                if not event_type or event_type not in EventTypes.values + ["Theater"]:
                     # record any data which would normally be linked with a
                     # Performance or Event object to Poster notes in case
                     # no such relation can be created
@@ -541,7 +540,7 @@ class Command(BaseCommand):
                                 obj_content_type=get_ct(Group),
                             )
 
-                    elif event_type in Event.EventTypes.values:
+                    elif event_type in EventTypes.values:
                         event = None
                         # Events can be about multiple works;
                         # data was linked to GND data

--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -348,6 +348,15 @@ class Group(BaseEntity, E74_Group):
     )
 
 
+class EventTypes(models.TextChoices):
+    EXHIBITION = "Ausstellung", _("exhibition")
+    BOOK_PRESENTATION = "Buchpräsentation", _("book presentation")
+    CONFERENCE = "Konferenz", _("conference")
+    BOOK_READING = "Lesung", _("book reading")
+    SCREENING = "Videovorführung", _("screening")
+    LECTURE = "Vortrag", _("lecture")
+
+
 class Event(BaseEntity):
     """
     Processes and interactions of a material nature, in cultural, social or
@@ -360,14 +369,6 @@ class Event(BaseEntity):
     Based on CIDOC CRM class E5 Event:
     https://cidoc-crm.org/html/cidoc_crm_v7.1.3.html#E5
     """
-
-    class EventTypes(models.TextChoices):
-        EXHIBITION = "Ausstellung", _("exhibition")
-        BOOK_PRESENTATION = "Buchpräsentation", _("book presentation")
-        CONFERENCE = "Konferenz", _("conference")
-        BOOK_READING = "Lesung", _("book reading")
-        SCREENING = "Videovorführung", _("screening")
-        LECTURE = "Vortrag", _("lecture")
 
     label = models.CharField(
         blank=True,


### PR DESCRIPTION
Move `TextChoices` for `EventTypes` out of `Event` entity class so it is no longer an inner class.