### PR TITLE
feat(forms): add BaseFilterSetForm class

### DIFF
--- a/apis_ontology/forms.py
+++ b/apis_ontology/forms.py
@@ -5,7 +5,15 @@ from apis_core.generic.forms import GenericFilterSetForm, GenericModelForm
 logger = logging.getLogger(__name__)
 
 
-class WorkFilterSetForm(GenericFilterSetForm):
+class BaseFilterSetForm(GenericFilterSetForm):
+    """
+    Base form for FilterSets. Used in filter sidebars.
+    """
+
+    pass
+
+
+class WorkFilterSetForm(BaseFilterSetForm):
     columns_exclude = ["tbit_category"]
 
 


### PR DESCRIPTION
Create base class for forms used by `FilterSets`, i.e. the forms used in the filter sidebar.
This class interits from the generic form class in Core but allows for customisation.