### PR TITLE
feat(models): add TextChoices classes for languages

### DIFF
--- a/apis_ontology/locale/de/LC_MESSAGES/django.po
+++ b/apis_ontology/locale/de/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-09 12:42+0100\n"
+"POT-Creation-Date: 2026-02-09 13:07+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: K Kollmann <dev-kk@oeaw.ac.at>\n"
 "Language-Team: \n"
@@ -87,6 +87,192 @@ msgstr "Adaptionen"
 msgctxt "TBit category"
 msgid "fragments"
 msgstr "Fragmente"
+
+#: apis_ontology/models.py
+msgid "Arabic"
+msgstr "Arabisch"
+
+#: apis_ontology/models.py
+msgid "Azerbaijani"
+msgstr "Aserbaidschanisch"
+
+#: apis_ontology/models.py
+msgid "Bulgarian"
+msgstr "Bulgarisch"
+
+#: apis_ontology/models.py
+msgid "Catalan"
+msgstr "Katalanisch"
+
+#: apis_ontology/models.py
+msgid "Czech"
+msgstr "Tschechisch"
+
+#: apis_ontology/models.py
+msgid "Danish"
+msgstr "Dänisch"
+
+#: apis_ontology/models.py apis_ontology/settings.py
+msgid "German"
+msgstr "Deutsch"
+
+#: apis_ontology/models.py
+msgid "Greek"
+msgstr "Griechisch"
+
+#: apis_ontology/models.py
+msgid "English"
+msgstr "Englisch"
+
+#: apis_ontology/models.py
+msgid "Spanish"
+msgstr "Spanisch"
+
+#: apis_ontology/models.py
+msgid "Estonian"
+msgstr "Estnisch"
+
+#: apis_ontology/models.py
+msgid "Basque"
+msgstr "Baskisch"
+
+#: apis_ontology/models.py
+msgid "Persian"
+msgstr "Persisch"
+
+#: apis_ontology/models.py
+msgid "Finnish"
+msgstr "Finnisch"
+
+#: apis_ontology/models.py
+msgid "French"
+msgstr "Französisch"
+
+#: apis_ontology/models.py
+msgid "Galician"
+msgstr "Galicisch"
+
+#: apis_ontology/models.py
+msgid "Hebrew"
+msgstr "Hebräisch"
+
+#: apis_ontology/models.py
+msgid "Croatian"
+msgstr "Kroatisch"
+
+#: apis_ontology/models.py
+msgid "Hungarian"
+msgstr "Ungarisch"
+
+#: apis_ontology/models.py
+msgid "Icelandic"
+msgstr "Isländisch"
+
+#: apis_ontology/models.py
+msgid "Italian"
+msgstr "Italienisch"
+
+#: apis_ontology/models.py
+msgid "Japanese"
+msgstr "Japanisch"
+
+#: apis_ontology/models.py
+msgid "Georgian"
+msgstr "Georgisch"
+
+#: apis_ontology/models.py
+msgid "Korean"
+msgstr "Koreanisch"
+
+#: apis_ontology/models.py
+msgid "Lithuanian"
+msgstr "Litauisch"
+
+#: apis_ontology/models.py
+msgid "Macedonian"
+msgstr "Mazedonisch"
+
+#: apis_ontology/models.py
+msgid "Dutch"
+msgstr "Niederländisch"
+
+#: apis_ontology/models.py
+msgid "Norwegian"
+msgstr "Norwegisch"
+
+#: apis_ontology/models.py
+msgid "Polish"
+msgstr "Polnisch"
+
+#: apis_ontology/models.py
+msgid "Portuguese"
+msgstr "Portugiesisch"
+
+#: apis_ontology/models.py
+msgid "Romanian"
+msgstr "Rumänisch"
+
+#: apis_ontology/models.py
+msgid "Russian"
+msgstr "Russisch"
+
+#: apis_ontology/models.py
+msgid "Slovak"
+msgstr "Slowakisch"
+
+#: apis_ontology/models.py
+msgid "Slovenian"
+msgstr "Slowenisch"
+
+#: apis_ontology/models.py
+msgid "Albanian"
+msgstr "Albanisch"
+
+#: apis_ontology/models.py
+msgid "Serbian"
+msgstr "Serbisch"
+
+#: apis_ontology/models.py
+msgid "Swedish"
+msgstr "Schwedisch"
+
+#: apis_ontology/models.py
+msgid "Turkish"
+msgstr "Türkisch"
+
+#: apis_ontology/models.py
+msgid "Ukrainian"
+msgstr "Ukrainisch"
+
+#: apis_ontology/models.py
+msgid "Urdu"
+msgstr "Urdu"
+
+#: apis_ontology/models.py
+msgid "Vietnamese"
+msgstr "Vietnamesisch"
+
+#: apis_ontology/models.py
+msgid "Chinese"
+msgstr "Chinesisch"
+
+#: apis_ontology/models.py
+msgid "Brazil"
+msgstr "Brasilien"
+
+#: apis_ontology/models.py
+msgid "Portugal"
+msgstr "Portugal"
+
+#: apis_ontology/models.py
+msgctxt "Chinese script variants"
+msgid "Han simplified"
+msgstr "Kurzzeichen"
+
+#: apis_ontology/models.py
+msgctxt "Chinese script variants"
+msgid "Han traditional"
+msgstr "Langzeichen"
 
 #: apis_ontology/models.py
 msgid "title"
@@ -294,10 +480,6 @@ msgstr "Plakat"
 #: apis_ontology/models.py
 msgid "posters"
 msgstr "Plakate"
-
-#: apis_ontology/settings.py
-msgid "German"
-msgstr "Deutsch"
 
 #: apis_ontology/tables.py
 msgid "full name"

--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -54,6 +54,78 @@ class TBitCategories(models.TextChoices):
     FRAGMENTS = "Fragmente", pgettext_lazy("TBit category", "fragments")
 
 
+class LanguageCodes(models.TextChoices):
+    """
+    ISO 639 codes for languages.
+
+    Covers all languages found in TBit data (see publications.json),
+    which use ISO 639-1 codes, but may in future be extended to
+    other languages, including ones which use 3-letter codes (in lieu
+    of 2-letter codes).
+    """
+
+    ARABIC = "ar", _("Arabic")
+    AZERBAIJANI = "az", _("Azerbaijani")
+    BULGARIAN = "bg", _("Bulgarian")
+    CATALAN = "ca", _("Catalan")
+    CZECH = "cs", _("Czech")
+    DANISH = "da", _("Danish")
+    GERMAN = "de", _("German")
+    GREEK = "el", _("Greek")
+    ENGLISH = "en", _("English")
+    SPANISH = "es", _("Spanish")
+    ESTONIAN = "et", _("Estonian")
+    BASQUE = "eu", _("Basque")
+    PERSIAN = "fa", _("Persian")
+    FINNISH = "fi", _("Finnish")
+    FRENCH = "fr", _("French")
+    GALICIAN = "gl", _("Galician")
+    HEBREW = "he", _("Hebrew")
+    CROATIAN = "hr", _("Croatian")
+    HUNGARIAN = "hu", _("Hungarian")
+    ICELANDIC = "is", _("Icelandic")
+    ITALIAN = "it", _("Italian")
+    JAPANESE = "ja", _("Japanese")
+    GEORGIAN = "ka", _("Georgian")
+    KOREAN = "ko", _("Korean")
+    LITHUANIAN = "lt", _("Lithuanian")
+    MACEDONIAN = "mk", _("Macedonian")
+    DUTCH = "nl", _("Dutch")
+    NORWEGIAN = "no", _("Norwegian")
+    POLISH = "pl", _("Polish")
+    PORTUGUESE = "pt", _("Portuguese")
+    ROMANIAN = "ro", _("Romanian")
+    RUSSIAN = "ru", _("Russian")
+    SLOVAK = "sk", _("Slovak")
+    SLOVENIAN = "sl", _("Slovenian")
+    ALBANIAN = "sq", _("Albanian")
+    SERBIAN = "sr", _("Serbian")
+    SWEDISH = "sv", _("Swedish")
+    TURKISH = "tr", _("Turkish")
+    UKRAINIAN = "uk", _("Ukrainian")
+    URDU = "ur", _("Urdu")
+    VIETNAMESE = "vi", _("Vietnamese")
+    CHINESE = "zh", _("Chinese")
+
+
+class PortugueseVariantCodes(models.TextChoices):
+    """
+    ISO 3166-1 alpha-2 codes for Portuguese language variants.
+    """
+
+    BRAZIL = "BR", _("Brazil")
+    PORTUGAL = "PT", _("Portugal")
+
+
+class ChineseVariantCodes(models.TextChoices):
+    """
+    ISO 15924 codes for Chinese script variants.
+    """
+
+    SIMPLIFIED = "Hans", pgettext_lazy("Chinese script variants", "Han simplified")
+    TRADITIONAL = "Hant", pgettext_lazy("Chinese script variants", "Han traditional")
+
+
 class BaseEntity(VersionMixin, AbstractEntity):
     """
     Base class for all entities.


### PR DESCRIPTION
Add `TextChoices` classes for language codes and language variant codes, `LanguageCodes`, `PortugueseVariantCodes`, `ChineseVariantCodes`, reflecting TBit data.