### PR TITLE
refactor(models): rename 'variant' to 'variety'

### DIFF
--- a/apis_ontology/locale/de/LC_MESSAGES/django.po
+++ b/apis_ontology/locale/de/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-09 13:07+0100\n"
+"POT-Creation-Date: 2026-02-10 12:10+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: K Kollmann <dev-kk@oeaw.ac.at>\n"
 "Language-Team: \n"
@@ -265,12 +265,12 @@ msgid "Portugal"
 msgstr "Portugal"
 
 #: apis_ontology/models.py
-msgctxt "Chinese script variants"
+msgctxt "Chinese script varieties"
 msgid "Han simplified"
 msgstr "Kurzzeichen"
 
 #: apis_ontology/models.py
-msgctxt "Chinese script variants"
+msgctxt "Chinese script varieties"
 msgid "Han traditional"
 msgstr "Langzeichen"
 

--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -108,22 +108,22 @@ class LanguageCodes(models.TextChoices):
     CHINESE = "zh", _("Chinese")
 
 
-class PortugueseVariantCodes(models.TextChoices):
+class PortugueseVarietyCodes(models.TextChoices):
     """
-    ISO 3166-1 alpha-2 codes for Portuguese language variants.
+    ISO 3166-1 alpha-2 codes for Portuguese language varieties.
     """
 
     BRAZIL = "BR", _("Brazil")
     PORTUGAL = "PT", _("Portugal")
 
 
-class ChineseVariantCodes(models.TextChoices):
+class ChineseVarietyCodes(models.TextChoices):
     """
-    ISO 15924 codes for Chinese script variants.
+    ISO 15924 codes for Chinese script varieties.
     """
 
-    SIMPLIFIED = "Hans", pgettext_lazy("Chinese script variants", "Han simplified")
-    TRADITIONAL = "Hant", pgettext_lazy("Chinese script variants", "Han traditional")
+    SIMPLIFIED = "Hans", pgettext_lazy("Chinese script varieties", "Han simplified")
+    TRADITIONAL = "Hant", pgettext_lazy("Chinese script varieties", "Han traditional")
 
 
 class BaseEntity(VersionMixin, AbstractEntity):


### PR DESCRIPTION
Update references to language "variants" to "varieties".