### PR TITLE
feat(api/tbit): limit PersonSerializer fields to necessary

### DIFF
--- a/apis_ontology/api/tbit/serializers.py
+++ b/apis_ontology/api/tbit/serializers.py
@@ -171,7 +171,13 @@ class PersonSerializer(BaseModelSerializer, ModelSerializer):
 
     class Meta:
         model = Person
-        fields = "__all__"
+        fields = [
+            "id",
+            "url",
+            "name",
+            "forename",  # needed for TBit name
+            "surname",  # needed for TBit name
+        ]
 
     def get_name(self, obj):
         """


### PR DESCRIPTION
In addition to `id` and `url` fields (via `BaseModelSerializer`)
and fields explicitly declared on `PersonSerializer`, only include
`Person` model fields needed by TBit (if only to create key-value
pairs expected by TBit) instead of setting `fields` to `__all__`.