### PR TITLE
docs(api/tbit): improve BaseModelSerializer docstring

### DIFF
--- a/apis_ontology/api/tbit/serializers.py
+++ b/apis_ontology/api/tbit/serializers.py
@@ -23,7 +23,8 @@ class BaseModelSerializer(GenericHyperlinkedModelSerializer):
     """
     Base serializer class for model classes.
 
-    Adds a field for the object ID (i.e. pk) and the URL to an entity object's
+    Adds an "id" field, which aliases an object's "pk".
+    Also implicitly includes a "url" field, which points to the object's
     detail view.
     """
 


### PR DESCRIPTION
Update `BaseModelSerializer` docstring to clarify implicit inclusion of `url` field (as opposed to `id` field, which is declared explicitly).