### PR TITLE
refactor(api/tbit): rename viewsets for clarity/usability

### DIFF
--- a/apis_ontology/api/tbit/urls.py
+++ b/apis_ontology/api/tbit/urls.py
@@ -6,16 +6,16 @@ from django.urls import include, path
 from rest_framework import routers
 
 from apis_ontology.api.tbit.views import (
-    ManifestationViewSet,
-    PersonIsTranslatorViewSet,
+    PublicationViewSet,
+    TranslatorViewSet,
     WorkViewSet,
 )
 
 router = routers.DefaultRouter()
 
 router.register(r"works", WorkViewSet, basename="work")
-router.register(r"publications", ManifestationViewSet, basename="publication")
-router.register(r"translators", PersonIsTranslatorViewSet, basename="translator")
+router.register(r"publications", PublicationViewSet, basename="publication")
+router.register(r"translators", TranslatorViewSet, basename="translator")
 
 urlpatterns = [
     path("api/tbit/", include((router.urls, "apis_ontology"))),

--- a/apis_ontology/api/tbit/views.py
+++ b/apis_ontology/api/tbit/views.py
@@ -18,21 +18,13 @@ class WorkViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Work.objects.all().exclude(tbit_category__exact="")
 
 
-class ManifestationViewSet(viewsets.ReadOnlyModelViewSet):
+class PublicationViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ManifestationSerializer
     queryset = Manifestation.objects.all().exclude(tbit_shelfmark__exact="")
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.name = f"Publication {self.suffix}"
 
-
-class PersonIsTranslatorViewSet(viewsets.ReadOnlyModelViewSet):
+class TranslatorViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = PersonIsTranslatorSerializer
     queryset = PersonIsTranslatorOfExpression.objects.order_by(
         "subj_object_id"
     ).distinct("subj_object_id")
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.name = f"Translator {self.suffix}"


### PR DESCRIPTION
Rename `ViewSet` classes to match terminology used by TBit. This incidentally makes it no longer necessary to manually set/override the (display) names of the viewsets in `__init__` to make them instantly recognisable/identifiable (as regards the data they present).