### PR TITLE
refactor(api/tbit): remove redundant QuerySet method

### DIFF
--- a/apis_ontology/api/tbit/views.py
+++ b/apis_ontology/api/tbit/views.py
@@ -25,13 +25,13 @@ class TbitPagination(LimitOffsetPagination):
 class WorkViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = TbitPagination
     serializer_class = WorkSerializer
-    queryset = Work.objects.all().exclude(tbit_category__exact="")
+    queryset = Work.objects.exclude(tbit_category__exact="")
 
 
 class PublicationViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = TbitPagination
     serializer_class = ManifestationSerializer
-    queryset = Manifestation.objects.all().exclude(tbit_shelfmark__exact="")
+    queryset = Manifestation.objects.exclude(tbit_shelfmark__exact="")
 
 
 class TranslatorViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
Remove unnecessary `all()` method when constructing `QuerySets` for various `ViewSet` classes with `exclude()`, as the latter is applied to the totality of objects anyway.