### PR TITLE
refactor(urls,api/tbit): set api path in urls

### DIFF
--- a/apis_ontology/api/tbit/urls.py
+++ b/apis_ontology/api/tbit/urls.py
@@ -18,5 +18,5 @@ router.register(r"publications", PublicationViewSet, basename="publication")
 router.register(r"translators", TranslatorViewSet, basename="translator")
 
 urlpatterns = [
-    path("api/tbit/", include((router.urls, "apis_ontology"))),
+    path("", include(router.urls)),
 ]

--- a/apis_ontology/urls.py
+++ b/apis_ontology/urls.py
@@ -1,7 +1,5 @@
 from apis_acdhch_default_settings.urls import urlpatterns
 from django.urls import include, path
 
-from .api.tbit.urls import urlpatterns as tbit_urls
-
 urlpatterns += [path("", include("django_interval.urls"))]
-urlpatterns += tbit_urls
+urlpatterns += [path("api/tbit/", include("apis_ontology.api.tbit.urls"))]


### PR DESCRIPTION
In `api.tbit.urls`, set `urlpatterns` without path, i.e. using only the routes for the API endpoints registered with the DRF router.
Set the actual path (prefix) for the entire TBit API in the app's overall `urls.py` file.