### PR TITLE
feat(api/tbit): remove superfluous serializer fields

### DIFF
--- a/apis_ontology/api/tbit/serializers.py
+++ b/apis_ontology/api/tbit/serializers.py
@@ -101,11 +101,7 @@ class ManifestationSerializer(BaseModelSerializer, ShortTitleMixin, ModelSeriali
         fields = [
             "id",
             "title",
-            "relevant_pages",  # needed for TBit publication_details
-            "other_title_information",  # needed for TBit publication_details
             "short_title",
-            "primary_language",  # needed for TBit language
-            "variety",  # needed for TBit language
             "language",
             "publication_details",
             "signatur",
@@ -187,8 +183,6 @@ class PersonSerializer(BaseModelSerializer, ModelSerializer):
             "id",
             "url",
             "name",
-            "forename",  # needed for TBit name
-            "surname",  # needed for TBit name
         ]
 
     def get_name(self, obj):


### PR DESCRIPTION
Remove model fields from serializers' `fields` setting which aren't needed beyond constructing other, TBit-specific key- value pairs from them.
Any model fields can actually be used in serializer methods just fine; the `fields` setting in a serializer's `Meta` class is meant for fields which should be rendered/passed on to view(set)s for rendering.