### PR TITLE
perf(api/tbit): (drastically) reduce TranslatorViewSet queries

### DIFF
--- a/apis_ontology/api/tbit/views.py
+++ b/apis_ontology/api/tbit/views.py
@@ -37,6 +37,9 @@ class PublicationViewSet(viewsets.ReadOnlyModelViewSet):
 class TranslatorViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = TbitPagination
     serializer_class = PersonIsTranslatorSerializer
-    queryset = PersonIsTranslatorOfExpression.objects.order_by(
-        "subj_object_id"
-    ).distinct("subj_object_id")
+    queryset = (
+        PersonIsTranslatorOfExpression.objects.select_related("subj_content_type")
+        .prefetch_related("subj")
+        .order_by("subj_object_id")
+        .distinct("subj_object_id")
+    )


### PR DESCRIPTION
Use `prefetch_related` on `subj`, i.e. `Person` data, and `select_related` for the content type when constructing the queryset for `TranslatorViewSet`.
This reduces the no. of queries made to the DB from over 50 (!) to 5 per result set (page).