### PR TITLE
fix(tbit_import): fix variable/value passed to argument

### DIFF
--- a/apis_ontology/management/commands/import_translations_data.py
+++ b/apis_ontology/management/commands/import_translations_data.py
@@ -485,7 +485,7 @@ class Command(BaseCommand):
                         pass
                     else:
                         expression = Expression.objects.create(
-                            title=exp_title, language=language
+                            title=exp_title, language=exp_language
                         )
 
                     manif_embodies_expr, created = (


### PR DESCRIPTION
Fix name of variable passed into `Expression` `language` field when importing translation data.