### PR TITLE
fix(tbit_import): assign value to variable

### DIFF
--- a/apis_ontology/management/commands/import_translations_data.py
+++ b/apis_ontology/management/commands/import_translations_data.py
@@ -472,6 +472,7 @@ class Command(BaseCommand):
 
                 for exp in matching_exp:
                     exp_title = exp["title"]
+                    exp_language = exp["language"] or ""
                     translator_ids = exp["translators"] or []
                     work_id = exp["work"] or ""
 


### PR DESCRIPTION
Actually assign the intended value to the `exp_language` variable, which is then used to look up/create `Expression` instances.