### PR TITLE
feat(forms): disable field reserved for TBit data

### DIFF
--- a/apis_ontology/forms.py
+++ b/apis_ontology/forms.py
@@ -27,5 +27,6 @@ class ManifestationForm(GenericModelForm):
         super().__init__(*args, **kwargs)
 
         if self.instance and self.instance.pk:
+            self.fields["tbit_shelfmark"].disabled = True
             self.fields["primary_language"].disabled = True
             self.fields["variety"].disabled = True


### PR DESCRIPTION
Disable `Manifestation` field `tbit_shelfmark` in `ManifestationForm`. The field's values are sourced from Thomas Bernhard in translation, so are not expected to need/want manual manipulation.