### PR TITLE
feat(forms): disable language fields conditionally

### DIFF
--- a/apis_ontology/forms.py
+++ b/apis_ontology/forms.py
@@ -36,5 +36,9 @@ class ManifestationForm(BaseModelForm):
 
         if self.instance and self.instance.pk:
             self.fields["tbit_shelfmark"].disabled = True
-            self.fields["primary_language"].disabled = True
-            self.fields["variety"].disabled = True
+
+            if self.instance.tbit_shelfmark != "":
+                # disable language fields only for Manifestations imported from
+                # TBit publications, to prevent (accidental) data manipulation
+                self.fields["primary_language"].disabled = True
+                self.fields["variety"].disabled = True


### PR DESCRIPTION
Set `ManifestationForm` language fields only disabled when the `Manifestation` was imported from Thomas Bernhard in translation data, i.e. when `tbit_shelfmark` is set.