### PR TITLE
feat(forms): sort ChoiceField values by choices labels

### DIFF
--- a/apis_ontology/forms.py
+++ b/apis_ontology/forms.py
@@ -1,6 +1,12 @@
 import logging
 
 from apis_core.generic.forms import GenericFilterSetForm, GenericModelForm
+from django.forms import (
+    ChoiceField,
+    MultipleChoiceField,
+    TypedChoiceField,
+    TypedMultipleChoiceField,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +24,34 @@ class BaseModelForm(GenericModelForm):
     Base form for models. Used in create/edit views.
     """
 
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if choice_fields := self.get_choice_fields():
+            for field_name in choice_fields:
+                self.fields[field_name] = ChoiceField(
+                    choices=sorted(self.fields[field_name].choices, key=lambda x: x[1]),
+                )
+
+    def get_choice_fields(self):
+        """
+        Get the names of all fields of type ChoiceField.
+
+        :return: a list of strings representing the names of the fields
+        :rtype: list
+        """
+        choice_fields = [
+            name
+            for name, f in self.fields.items()
+            if type(f)
+            in (
+                ChoiceField,
+                MultipleChoiceField,
+                TypedChoiceField,
+                TypedMultipleChoiceField,
+            )
+        ]
+        return choice_fields
 
 
 class WorkFilterSetForm(BaseFilterSetForm):


### PR DESCRIPTION
Add `get_choice_fields` method to base ModelForm to identify `ChoiceFields`, then reorder each applicable field's choices by their human-readable labels (rather than their values), so they appear in alphabetically order (the way users would expect).

Solves: #539