### PR TITLE
fix(forms): only update ChoiceField choices when reordering

### DIFF
--- a/apis_ontology/forms.py
+++ b/apis_ontology/forms.py
@@ -29,8 +29,8 @@ class BaseModelForm(GenericModelForm):
 
         if choice_fields := self.get_choice_fields():
             for field_name in choice_fields:
-                self.fields[field_name] = ChoiceField(
-                    choices=sorted(self.fields[field_name].choices, key=lambda x: x[1]),
+                self.fields[field_name].choices = sorted(
+                    self.fields[field_name].choices, key=lambda x: x[1]
                 )
 
     def get_choice_fields(self):


### PR DESCRIPTION
When reordering `ChoiceFields`' `choices`, don't (re)set/ (re)assign the entire field but only set the `choices` themselves.

Fixes: #549