### PR TITLE
chore: clean up .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,18 +25,3 @@ build
 
 # exceptions from above ignore rules
 !/apis_ontology/**/locale/
-
-# Devenv
-.devenv*
-devenv.local.nix
-devenv.local.yaml
-devenv.*
-
-# direnv
-.direnv
-
-# pre-commit
-.pre-commit-config.yaml
-
-# local dev
-settings_*


### PR DESCRIPTION
Clean up/restore main `.gitignore` file by removing (arbitrarily) added ignore rules not used/needed by the main dev of the app.