### PR TITLE
chore(gitignore): ignore PyCharm run configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # OS, IDEs, tooling
 .DS_Store
 .idea/
+.run/
 .python-version
 
 # settings files / local development


### PR DESCRIPTION
Ignore `.run` directory, which is used by PyCharm
to store (reusable) run configurations.