### PR TITLE
fix(settings): set TIME_ZONE to continent/country

### DIFF
--- a/apis_ontology/settings.py
+++ b/apis_ontology/settings.py
@@ -49,7 +49,7 @@ LANGUAGES = [
     ("de", _("German")),
 ]
 
-TIME_ZONE = "CET"
+TIME_ZONE = "Europe/Vienna"
 
 # Static file settings
 # https://docs.djangoproject.com/en/stable/ref/settings/#static-files


### PR DESCRIPTION
`CET` appears to not be a valid `TIME_ZONE` setting on all systems. This changes the variable's value to "Europe/Vienna" to be on the safe side.