### PR TITLE
feat: exclude Markdown file from analysis by Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ ignore="H006"
 
 [tool.ruff]
 src = ["apis_ontology"]
+exclude = ["data/posters/README.md"]
 
 [tool.ruff.format]
 line-ending = "lf"


### PR DESCRIPTION
Exclude the `README.md` file in `data/posters` from analysis by Ruff to prevent the tool from reformatting a code block which contains a "bastardised" version of JSON code, which was given a language identifier of "Python" for readability.